### PR TITLE
Feat : 챗봇 컴포넌트 구현

### DIFF
--- a/components/Chatbot.tsx
+++ b/components/Chatbot.tsx
@@ -27,7 +27,7 @@ function chatbot() {
     setLoading(true);
 
     const data = buildRequestData(messages);
-
+    // TODO : 실제 llm 주소로 변경해야함.
     try {
       const response = await axios.post("/llm", {
         data

--- a/components/Chatbot.tsx
+++ b/components/Chatbot.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useRef, useEffect } from "react";
+import axios from "axios";
+import chatbotStore from "@/store/chatbotStore";
+import { buildRequestData } from "@/utils/chatbotUtils";
+
+function chatbot() {
+  const messages = chatbotStore(state => state.messages);
+  const addMessage = chatbotStore(state => state.addMessage);
+  const initMessages = chatbotStore(state => state.initMessages);
+  const input = chatbotStore(state => state.input);
+  const setInput = chatbotStore(state => state.setInput);
+  const loading = chatbotStore(state => state.loading);
+  const setLoading = chatbotStore(state => state.setLoading);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const handleSend = async () => {
+    if (!input.trim()) return;
+    const userMsg = { role: "user", text: input };
+    addMessage(userMsg);
+    setInput("");
+    setLoading(true);
+
+    const data = buildRequestData(messages);
+
+    try {
+      const response = await axios.post("/llm", {
+        data
+      });
+      const botMsg = {
+        role: "bot",
+        text: response.data.response.answer || "죄송합니다. 답변을 찾지 못했습니다."
+      };
+      addMessage(botMsg);
+    } catch (error) {
+      addMessage({ role: "bot", text: "현재 답변이 불가능한 상태입니다." });
+    }
+    setLoading(false);
+  };
+
+  const handleKeyDown = (e: any) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  const handleReset = () => {
+    initMessages();
+    setInput("");
+  };
+
+  return (
+    <div className="flex flex-col h-full w-full">
+      <div className="flex-1 overflow-y-auto p-3 border rounded bg-slate-50 mb-2">
+        {messages.map((msg, idx) => (
+          <div
+            key={idx}
+            className={
+              msg.role === "user"
+                ? "text-left flex justify-end mb-2"
+                : "text-left flex justify-start mb-2"
+            }
+          >
+            <div
+              className={
+                msg.role === "user"
+                  ? "inline-block bg-blue-100 text-blue-800 px-3 py-1 rounded-lg max-w-xs"
+                  : "inline-block bg-gray-200 text-gray-800 px-3 py-1 rounded-lg max-w-xs"
+              }
+            >
+              {msg.text}
+            </div>
+          </div>
+        ))}
+        <div ref={messagesEndRef} />
+      </div>
+      {/* 입력창 */}
+      <form
+        className="flex gap-2"
+        onSubmit={e => {
+          e.preventDefault();
+          handleSend();
+        }}
+      >
+        <input
+          type="text"
+          className="flex-1 border rounded px-2 py-1"
+          placeholder="질문을 입력하세요..."
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={loading}
+        />
+        <button
+          type="button"
+          className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-40"
+          disabled={loading}
+          onClick={() => handleReset()}
+        >
+          리셋
+        </button>
+        <button
+          type="submit"
+          className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-40"
+          disabled={!input.trim() || loading}
+        >
+          보내기
+        </button>
+      </form>
+    </div>
+  );
+}
+
+
+export default chatbot;

--- a/components/ChatbotButton.tsx
+++ b/components/ChatbotButton.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { useState } from "react";
+import Modal from "./Modal";
+import Chatbot from "@/components/Chatbot"
+
+function chatbotButton(){
+  const [modalOpen, setModalOpen] = useState(false);
+  const handleClose = () => {
+    setModalOpen(false);
+  };
+
+  return (
+    <>
+    <button
+      aria-label="챗봇 열기"
+      onClick={() => setModalOpen(true)}
+      className="fixed top-2 right-5 border border-gray-300 text-gray-500 bg-white shadow rounded-full w-8 h-8 flex items-center justify-center z-50 hover:border-gray-500 hover:text-black"
+    >
+    <svg
+      width={18}
+      height={18}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M8 8a3.5 3 0 0 1 3.5-3h1a3.5 3 0 0 1 3.5 3 3 3 0 0 1-2 3 3 4 0 0 0-2 4" />
+      <path d="M12 19l0 .01" />
+    </svg>
+  </button>
+
+    {modalOpen && (
+      <Modal open={modalOpen} onClose={handleClose}>
+        <Chatbot />
+      </Modal>
+    )}
+  </>
+  );
+}
+
+export default chatbotButton;

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -1,3 +1,5 @@
+import ChatbotButton from "@/components/ChatbotButton";
+
 function CommonHeader() {
   return (
     <header className="bg-white shadow border-[1px] border-[#b1b1b1]">
@@ -11,6 +13,7 @@ function CommonHeader() {
           </li>
         </ul>
       </nav>
+      <ChatbotButton />
     </header>
   );
 };

--- a/store/chatbotStore.tsx
+++ b/store/chatbotStore.tsx
@@ -1,0 +1,26 @@
+import { Message } from "@/utils/chatbotUtils";
+import { create } from "zustand";
+
+type ChatbotStore = {
+  messages: Message[];
+  addMessage: (message: Message) => void;
+  initMessages: () => void;
+  input: string;
+  setInput: (input: string) => void;
+  loading: boolean;
+  setLoading: (loading: boolean) => void;
+}
+
+const chatbotStore = create<ChatbotStore> ((set) => ({
+  messages: [],
+  addMessage: (message) => set(state => ({
+    messages: [...state.messages, message]
+  })),
+  initMessages: () => set({ messages: [] }),
+  input: "",
+  setInput: (input) => (set({ input })),
+  loading : false,
+  setLoading: (loading) => (set({ loading })),
+}))
+
+export default chatbotStore;

--- a/store/detectedObjectStore.tsx
+++ b/store/detectedObjectStore.tsx
@@ -40,7 +40,7 @@ const detectedObjectStore = create<DetectedObjectStore>((set) => ({
   setSelectedVideos: async (detectedObjectId: number, startTime: string, endTime: string) => {
     const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
     try {
-      const res = await axios.get<DetectedObject[]>(`${backendUrl}/api/v1/detection/tracks`,
+      const res = await axios.get(`${backendUrl}/api/v1/detection/tracks`,
         {
           params: {
             detectedObjectId: detectedObjectId,

--- a/utils/chatbotUtils.tsx
+++ b/utils/chatbotUtils.tsx
@@ -1,0 +1,22 @@
+export type Message = {
+  role: string;
+  text: string;
+}
+
+export function buildRequestData(messages: Message[]) {
+  const data = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].role === "user") {
+      // 다음 메시지가 bot인 경우 answer로 세팅, 없거나 user면 빈 문자열
+      const next = messages[i + 1];
+      data.push({
+        question: messages[i].text,
+        answer:
+          next && next.role === "bot"
+            ? next.text
+            : ""
+      });
+    }
+  }
+  return { data };
+}


### PR DESCRIPTION
챗봇 기능 구현을 위한 과정은 아래와 같습니다.

1. ChatbotButton 컴포넌트 구현 : 헤더의 오른쪽 끝에 ? 버튼을 추가하고, 해당 버튼을 누를 시 Chatbot 컴포넌트가 포함된 모달창이 뜨게 됩니다.
2. Chatbot 컴포넌트 구현 : 사용자의 질문 및 챗봇 모델의 답변을 확인할 수 있고, 질문을 입력할 수 있으며, 리셋 버튼을 통해 대화 내역을 초기화할 수 있습니다.
3. chatbotStore 구현 : 페이지를 이동하더라도 대화 내역이 사라지지 않도록 대화 기록 및 입력값을 전역 상태로 관리하였습니다.
4. chatbotUtils 구현 :  메시지의 타입을 정의하고, LLM에 reqeust api를 보낼 시 messages의 값을 형식에 맞게 변경하는 함수를 추가하였습니다.

※ 현재 LLM 모델의 경우 서버에 배포되지 않아 연동은 진행하지 않았습니다. 추후 실제 주소 및 메타데이터 활용 방안이 추가될 경우 수정하겠습니다.